### PR TITLE
use io.BytesIO instead of StringIO.StringIO for compressed data

### DIFF
--- a/flask_gzip.py
+++ b/flask_gzip.py
@@ -1,5 +1,9 @@
 import gzip
-import StringIO
+try:
+    from io import BytesIO
+except ImportError:
+    from StringIO import StringIO as BytesIO
+
 from flask import request
 
 
@@ -20,7 +24,7 @@ class Gzip(object):
            'Content-Encoding' in response.headers:
             return response
 
-        gzip_buffer = StringIO.StringIO()
+        gzip_buffer = BytesIO()
         gzip_file = gzip.GzipFile(mode='wb', compresslevel=self.compress_level, fileobj=gzip_buffer)
         gzip_file.write(response.data)
         gzip_file.close()

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]


### PR DESCRIPTION
This makes flask_gzip Python 3-compatible.
