### PR TITLE
Allow the app initialization to be postponed

### DIFF
--- a/flask_gzip.py
+++ b/flask_gzip.py
@@ -6,10 +6,14 @@ from flask import request
 
 class Gzip(object):
     def __init__(self, app, compress_level=6, minimum_size=500):
-        self.app = app
         self.compress_level = compress_level
         self.minimum_size = minimum_size
-        self.app.after_request(self.after_request)
+
+        if app is not None:
+            self.init_app(app)
+    
+    def init_app(self, app):
+        app.after_request(self.after_request)
 
     def after_request(self, response):
         accept_encoding = request.headers.get('Accept-Encoding', '')


### PR DESCRIPTION
This is a widely used pattern (even in the [Flask Extension Development docs][f]) and is useful for all kinds of tricks. My usecase is not a really good one but it would work OK: 

```py
app = Flask()
cache = Cache(app)
gzip = Gzip()
gzip.after_request = \
    cache.memoize(timeout=24 * 60 * 60, key_prefix="gzip")(gzip.after_request)
gzip.init_app(app)
```

Right now one would need to subclass Gzip in order to do that.

[f]: https://flask.palletsprojects.com/en/1.1.x/extensiondev/#the-extension-code